### PR TITLE
Fix block expression with chained ident

### DIFF
--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -45,7 +45,7 @@ elseExpression
   }
 
 blockExpression
-  = _ dash _ name:ident _ m:text? _ TERM b:(INDENT elements DEDENT TERM?)?
+  = _ dash _ name:identChain _ m:text? _ TERM b:(INDENT elements DEDENT TERM?)?
   {
     var e = { type: 'block_expression', name:name };
     if(m) {

--- a/tests/parser_test.js
+++ b/tests/parser_test.js
@@ -319,6 +319,29 @@ describe('parser', function () {
     ]);
   });
 
+  it('contextual components', function () {
+    var ast = parse('- x-foo as |f|\n  - f.bar\n    %div');
+    expect(ast).to.deep.equal([
+      {
+        type: "block_expression",
+        name: "x-foo",
+        content: "as |f|",
+        nodes: [
+          {
+            type: "block_expression",
+            name: "f.bar",
+            nodes: [
+              {
+                type: "element",
+                tag: "div"
+              }
+            ]
+          }
+        ]
+      }
+    ]);
+  });
+
   describe('attributes', function() {
 
     it('static', function () {


### PR DESCRIPTION
When contextual component is used, a dot is included in a helper name.
